### PR TITLE
Add data from external lightning sensor WH57

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ for whom this will be a difficult time.
 | `WIND_UNIT`        | `kmh`                    | `kmh`, `mph`, `ms`, `knots`, `fps` | Speed in km/hour, miles/hour, metres/second, knots or feet/second        |
 | `RAIN_UNIT`        | `mm`                     | `mm`, `in`                         | Rainfall in millimetres or inches                                        |
 | `IRRADIANCE_UNIT`  | `wm2`                    | `wm2`, `lx`, `fc`                  | Solar irradiance in Watts/m^2                                            |
+| `DISTANCE_UNIT`    | `km`                     | `km`, `mi`                         | Distance from the last lightning in kilometers                           |
 | `INFLUXDB_TOKEN`   |                          |                                    | InfluxDB token                                                           |
 | `INFLUXDB_URL`     | `http://localhost:8086/` |                                    | InfluxDB endpoint                                                        |
 | `INFLUXDB_ORG`     | `influxdata`             |                                    | InfluxDB organisation                                                    |
@@ -112,7 +113,7 @@ Real data captured from the Ecowitt weather station with [http-webhook](https://
 This POST request can be simulated with curl:
 
 ```
-curl -d "PASSKEY=573AF40DB42C66057D20631F706CD585&stationtype=EasyWeatherPro_V5.1.1&runtime=1&dateutc=2023-06-20+14:56:02&tempinf=73.4&humidityin=49&baromrelin=29.917&baromabsin=29.536&tempf=72.5&humidity=58&winddir=251&windspeedmph=1.12&windgustmph=2.24&maxdailygust=9.17&solarradiation=293.99&uv=2&rainratein=0.000&eventrainin=0.638&hourlyrainin=0.000&dailyrainin=0.638&weeklyrainin=0.650&monthlyrainin=0.650&yearlyrainin=0.650&totalrainin=0.650&wh65batt=0&freq=868M&model=WS2900_V2.01.18&interval=60" -X POST http://192.168.0.65:8080/report
+curl -d "PASSKEY=573AF40DB42C66057D20631F706CD585&stationtype=EasyWeatherPro_V5.1.1&runtime=1&dateutc=2023-06-20+14:56:02&tempinf=73.4&humidityin=49&baromrelin=29.917&baromabsin=29.536&tempf=72.5&humidity=58&winddir=251&windspeedmph=1.12&windgustmph=2.24&maxdailygust=9.17&solarradiation=293.99&uv=2&rainratein=0.000&eventrainin=0.638&hourlyrainin=0.000&dailyrainin=0.638&weeklyrainin=0.650&monthlyrainin=0.650&yearlyrainin=0.650&totalrainin=0.650&wh65batt=0&freq=868M&model=WS2900_V2.01.18&interval=60&lightning_num=22&lightning=20&lightning_time=1691007186" -X POST http://192.168.0.65:8080/report
 ```
 
 We can then view the corresponding Prometheus metrics with a simple GET request (output has been truncated because it is very long):
@@ -179,4 +180,16 @@ yearlyrain_mm 616.1
 # HELP totalrain_mm Total rainfall
 # TYPE totalrain_mm gauge
 totalrain_mm 616.1
+# HELP lightning_km Lightning distance
+# TYPE lightning_km gauge
+lightning_km 20.0
+# HELP lightning_num Lightning daily count
+# TYPE lightning_num gauge
+lightning_num 22.0
+```
+
+## Building and running locally
+```
+docker build -t ecowitt-exporter .
+podman run -d --rm -p 8088:8088 -e DEBUG=yes ecowitt-exporter
 ```

--- a/ecowitt_exporter.py
+++ b/ecowitt_exporter.py
@@ -13,6 +13,7 @@ temperature_unit = os.environ.get('TEMPERATURE_UNIT', 'c')
 pressure_unit = os.environ.get('PRESSURE_UNIT', 'hpa')
 wind_unit = os.environ.get('WIND_UNIT', 'kmh')
 rain_unit = os.environ.get('RAIN_UNIT', 'mm')
+distance_unit = os.environ.get('DISTANCE_UNIT', 'km')
 irradiance_unit = os.environ.get('IRRADIANCE_UNIT', 'wm2')
 influxdb_token = os.environ.get('INFLUXDB_TOKEN', None)
 influxdb_url = os.environ.get('INFLUXDB_URL', 'http://localhost:8086/')
@@ -30,6 +31,7 @@ print ('  TEMPERATURE_UNIT: ' + temperature_unit)
 print ('  PRESSURE_UNIT:    ' + pressure_unit)
 print ('  WIND_UNIT:        ' + wind_unit)
 print ('  RAIN_UNIT:        ' + rain_unit)
+print ('  DISTANCE_UNIT:    ' + distance_unit)
 print ('  IRRADIANCE_UNIT:  ' + irradiance_unit)
 print ('  INFLUXDB_TOKEN:   ' + str(influxdb_token))
 print ('  INFLUXDB_URL:     ' + influxdb_url)
@@ -108,7 +110,7 @@ def logecowitt():
             continue
 
         # No conversions needed
-        if key in ['humidity', 'humidityin', 'winddir', 'uv', 'pm25_ch1', 'pm25_avg_24h_ch1', 'pm25batt1', 'wh65batt']:
+        if key in ['humidity', 'humidityin', 'winddir', 'uv', 'pm25_ch1', 'pm25_avg_24h_ch1', 'pm25batt1', 'wh65batt', 'lightning_num']:
             results[key] = value
 
         # Solar irradiance, default W/m^2
@@ -180,6 +182,16 @@ def logecowitt():
             key = key[:-2]
             results[key] = value
 
+        # Lightning distance, default kilometers
+        if key in ['lightning']:
+            if distance_unit == 'km':
+                results[key] = value
+            elif distance_unit == 'mi':
+                # Convert km to miles
+                distancemi = float(value) / 1.60934
+                value = "{:.2f}".format(distancemi)
+                results[key] = value
+
     # Now loop on our processed results and do things with them
     points = []
     for key, value in results.items():
@@ -245,6 +257,8 @@ if __name__ == "__main__":
     metrics['monthlyrain'] = Gauge(name='monthlyrain', documentation='Monthly rainfall', unit=rain_unit)
     metrics['yearlyrain'] = Gauge(name='yearlyrain', documentation='Yearly rainfall', unit=rain_unit)
     metrics['totalrain'] = Gauge(name='totalrain', documentation='Total rainfall', unit=rain_unit)
+    metrics['lightning'] = Gauge(name='lightning', documentation='Lightning distance', unit=distance_unit)
+    metrics['lightning_num'] = Gauge(name='lightning_num', documentation='Lightning daily count')
 
     # Increase Flask logging if in debug mode
     if debug:


### PR DESCRIPTION
Good evening,

thank you for your great software, I use Ecowitt just few hours but Prometheus integration would be showstopper for me.
Besides [WS69](https://shop.ecowitt.com/products/ws69) outdoor unit and [WN1980_C](https://shop.ecowitt.com/products/wn1980_c) console I bought also [WH57](https://shop.ecowitt.com/products/wh57) lightning sensor. You can find the PDF manual [here](https://www.ecowitt.com/api/quickstart/product?id=64&_gl=1*2a3x32*_ga*MzE0Njk0NC4xNjkxMDAwMDc2*_ga_4EK9KDRE8Q*MTY5MTAxMDUwOS4yLjEuMTY5MTAxMTIyNS41MS4wLjA.).

There is last lightning timestamp which I decided to ignore, numbers of lightnings per day and last lightning distance which in my case is in kilometers.

Please let me know if something is not up to your expectations and I will be happy to further tweak this pull request.

Once again thank you very much

Pavel
