### PR TITLE
Drop InfluxDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ecowitt-exporter
 
-Ecowitt exporter for Prometheus & InfluxDB
+Ecowitt exporter for Prometheus
 
 The WiFi-enabled Ecowitt weather stations can export metrics in a number of protocols to various online weather services, as a push operation.
 They also support pushing to a custom endpoint in a choice of two protocols, Ecowitt or Wunderground. Blogger Ernest Neijenhuis has
@@ -54,22 +54,16 @@ alternatives, while Brits will likely want a mixture of both!
 All units are expressed in lower case and without slashes, for simplicity. Apologies to scientists,
 for whom this will be a difficult time.
 
-| Variable           | Default                  | Choices                            | Meaning                                                                  |
-|--------------------|--------------------------|------------------------------------|--------------------------------------------------------------------------|
-| `DEBUG`            | `no`                     | `no`, `yes`                        | Enable extra output for debugging                                        |
-| `PROMETHEUS`       | `yes`                    | `no`, `yes`                        | Enable Prometheus exporter                                               |
-| `INFLUXDB`         | `no`                     | `no`, `yes`                        | Enable InfluxDB support                                                  |
-| `TEMPERATURE_UNIT` | `c`                      | `c`, `f`, `k`                      | Temperature in Celsius, Fahrenheit or Kelvin                             |
-| `PRESSURE_UNIT`    | `hpa`                    | `hpa`, `in`, `mmhg`                | Pressure in hectopascals (millibars), inches of mercury or mm of mercury |
-| `WIND_UNIT`        | `kmh`                    | `kmh`, `mph`, `ms`, `knots`, `fps` | Speed in km/hour, miles/hour, metres/second, knots or feet/second        |
-| `RAIN_UNIT`        | `mm`                     | `mm`, `in`                         | Rainfall in millimetres or inches                                        |
-| `IRRADIANCE_UNIT`  | `wm2`                    | `wm2`, `lx`, `fc`                  | Solar irradiance in Watts/m^2                                            |
-| `DISTANCE_UNIT`    | `km`                     | `km`, `mi`                         | Distance from the last lightning in kilometers                           |
-| `AQI_STANDARD`     | `uk`                     | `uk`, `epa`, `mep`, `nepm`         | Air Quality Index standard in UK DAQI, US EPA, China MEP, Australia NEPM |
-| `INFLUXDB_TOKEN`   |                          |                                    | InfluxDB token                                                           |
-| `INFLUXDB_URL`     | `http://localhost:8086/` |                                    | InfluxDB endpoint                                                        |
-| `INFLUXDB_ORG`     | `influxdata`             |                                    | InfluxDB organisation                                                    |
-| `INFLUXDB_BUCKET`  | `default`                |                                    | InfluxDB bucket                                                          |
+| Variable           | Default | Choices                            | Meaning                                                                  |
+|--------------------|---------|------------------------------------|--------------------------------------------------------------------------|
+| `DEBUG`            | `no`   | `no`, `yes`                        | Enable extra output for debugging                                        |
+| `TEMPERATURE_UNIT` | `c`    | `c`, `f`, `k`                      | Temperature in Celsius, Fahrenheit or Kelvin                             |
+| `PRESSURE_UNIT`    | `hpa`  | `hpa`, `in`, `mmhg`                | Pressure in hectopascals (millibars), inches of mercury or mm of mercury |
+| `WIND_UNIT`        | `kmh`  | `kmh`, `mph`, `ms`, `knots`, `fps` | Speed in km/hour, miles/hour, metres/second, knots or feet/second        |
+| `RAIN_UNIT`        | `mm`   | `mm`, `in`                         | Rainfall in millimetres or inches                                        |
+| `IRRADIANCE_UNIT`  | `wm2`  | `wm2`, `lx`, `fc`                  | Solar irradiance in Watts/m^2                                            |
+| `DISTANCE_UNIT`    | `km`   | `km`, `mi`                         | Distance from the last lightning in kilometers                           |
+| `AQI_STANDARD`     | `uk`   | `uk`, `epa`, `mep`, `nepm`         | Air Quality Index standard in UK DAQI, US EPA, China MEP, Australia NEPM |
 
 If you want to use one of the units that is not yet supported, please [open an issue](https://github.com/djjudas21/ecowitt-exporter/issues)
 and request it. I can add the code to convert and display other units if there is demand.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 flask==2.3.3
 werkzeug==2.3.8
 prometheus_client==0.21.1
-influxdb-client==1.36.1
 python-aqi==0.6.1


### PR DESCRIPTION
Drop support for InfluxDB, since it's no longer viable for home use as v3 only supports 30 day retention on the free/personal tier.

Fixes #32 