### PR TITLE
Don't specify unit in metric name, but as a label

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,31 +127,31 @@ ecowitt_freq_info{freq="868M"} 1.0
 # HELP ecowitt_model_info Ecowitt model
 # TYPE ecowitt_model_info gauge
 ecowitt_model_info{model="GW1100A"} 1.0
-# HELP ecowitt_temp_c Temperature
-# TYPE ecowitt_temp_c gauge
-ecowitt_temp_c{sensor="indoor"} 30.1
-ecowitt_temp_c{sensor="outdoor"} 17.7
-ecowitt_temp_c{sensor="ch1"} 23.5
-ecowitt_temp_c{sensor="ch2"} 21.7
-ecowitt_temp_c{sensor="ch3"} 24.4
-ecowitt_temp_c{sensor="ch4"} 22.8
-ecowitt_temp_c{sensor="ch5"} 24.3
-ecowitt_temp_c{sensor="ch6"} 25.4
-ecowitt_temp_c{sensor="ch8"} 23.3
-# HELP ecowitt_humidity_percent Relative humidity
-# TYPE ecowitt_humidity_percent gauge
-ecowitt_humidity_percent{sensor="indoor"} 41.0
-ecowitt_humidity_percent{sensor="outdoor"} 75.0
-ecowitt_humidity_percent{sensor="ch1"} 57.0
-ecowitt_humidity_percent{sensor="ch2"} 61.0
-ecowitt_humidity_percent{sensor="ch3"} 54.0
-ecowitt_humidity_percent{sensor="ch4"} 62.0
-ecowitt_humidity_percent{sensor="ch5"} 54.0
-ecowitt_humidity_percent{sensor="ch6"} 45.0
-ecowitt_humidity_percent{sensor="ch8"} 58.0
-# HELP ecowitt_winddir_degree Wind direction
-# TYPE ecowitt_winddir_degree gauge
-ecowitt_winddir_degree 173.0
+# HELP ecowitt_temp Temperature
+# TYPE ecowitt_temp gauge
+ecowitt_temp{sensor="indoor",unit="c"} 30.1
+ecowitt_temp{sensor="outdoor",unit="c"} 17.7
+ecowitt_temp{sensor="ch1",unit="c"} 23.5
+ecowitt_temp{sensor="ch2",unit="c"} 21.7
+ecowitt_temp{sensor="ch3",unit="c"} 24.4
+ecowitt_temp{sensor="ch4",unit="c"} 22.8
+ecowitt_temp{sensor="ch5",unit="c"} 24.3
+ecowitt_temp{sensor="ch6",unit="c"} 25.4
+ecowitt_temp{sensor="ch8",unit="c"} 23.3
+# HELP ecowitt_humidity Relative humidity
+# TYPE ecowitt_humidity gauge
+ecowitt_humidity{sensor="indoor",unit="percent"} 41.0
+ecowitt_humidity{sensor="outdoor",unit="percent"} 75.0
+ecowitt_humidity{sensor="ch1",unit="percent"} 57.0
+ecowitt_humidity{sensor="ch2",unit="percent"} 61.0
+ecowitt_humidity{sensor="ch3",unit="percent"} 54.0
+ecowitt_humidity{sensor="ch4",unit="percent"} 62.0
+ecowitt_humidity{sensor="ch5",unit="percent"} 54.0
+ecowitt_humidity{sensor="ch6",unit="percent"} 45.0
+ecowitt_humidity{sensor="ch8",unit="percent"} 58.0
+# HELP ecowitt_winddir Wind direction
+# TYPE ecowitt_winddir gauge
+ecowitt_winddir 173.0
 # HELP ecowitt_uv UV index
 # TYPE ecowitt_uv gauge
 ecowitt_uv 0.0
@@ -179,47 +179,47 @@ ecowitt_batterylevel{sensor="wh57batt"} 4.0
 # HELP ecowitt_batteryvoltage Battery voltage
 # TYPE ecowitt_batteryvoltage gauge
 ecowitt_batteryvoltage{sensor="soilbatt1"} 1.7
-# HELP ecowitt_solarradiation_wm2 Solar irradiance
-# TYPE ecowitt_solarradiation_wm2 gauge
-ecowitt_solarradiation_wm2 29.22
-# HELP ecowitt_barom_hpa Barometer
-# TYPE ecowitt_barom_hpa gauge
-ecowitt_barom_hpa{sensor="relative"} 1008.6
-# HELP ecowitt_vpd_hpa Vapour pressure deficit
-# TYPE ecowitt_vpd_hpa gauge
-ecowitt_vpd_hpa 5.08
-# HELP ecowitt_windspeed_kmh Wind speed
-# TYPE ecowitt_windspeed_kmh gauge
-ecowitt_windspeed_kmh{sensor="windspeed"} 0.0
-ecowitt_windspeed_kmh{sensor="windgust"} 5.41
-ecowitt_windspeed_kmh{sensor="maxdailygust"} 11.15
+# HELP ecowitt_solarradiation Solar irradiance
+# TYPE ecowitt_solarradiation gauge
+ecowitt_solarradiation{unit="wm2"} 29.22
+# HELP ecowitt_barom Barometer
+# TYPE ecowitt_barom gauge
+ecowitt_barom{sensor="relative",unit="hpa"} 1008.6
+# HELP ecowitt_vpd Vapour pressure deficit
+# TYPE ecowitt_vpd gauge
+ecowitt_vpd{unit="hpa"} 5.08
+# HELP ecowitt_windspeed Wind speed
+# TYPE ecowitt_windspeed gauge
+ecowitt_windspeed{sensor="windspeed",unit="kmh"} 0.0
+ecowitt_windspeed{sensor="windgust",unit="kmh"} 5.41
+ecowitt_windspeed{sensor="maxdailygust",unit="kmh"} 11.15
 # HELP ecowitt_windspeed_beaufort Wind Beaufort scale
 # TYPE ecowitt_windspeed_beaufort gauge
 ecowitt_windspeed_beaufort 0.0
-# HELP ecowitt_rain_mm Rainfall
-# TYPE ecowitt_rain_mm gauge
-ecowitt_rain_mm{sensor="rate"} 0.0
-ecowitt_rain_mm{sensor="event"} 0.0
-ecowitt_rain_mm{sensor="hourly"} 0.0
-ecowitt_rain_mm{sensor="daily"} 0.0
-ecowitt_rain_mm{sensor="weekly"} 17.7
-ecowitt_rain_mm{sensor="monthly"} 30.7
-ecowitt_rain_mm{sensor="yearly"} 210.3
-ecowitt_rain_mm{sensor="total"} 210.3
-# HELP ecowitt_lightning_km Lightning distance
-# TYPE ecowitt_lightning_km gauge
-ecowitt_lightning_km 34.0
+# HELP ecowitt_rain Rainfall
+# TYPE ecowitt_rain gauge
+ecowitt_rain{sensor="rate",unit="mm"} 0.0
+ecowitt_rain{sensor="event",unit="mm"} 0.0
+ecowitt_rain{sensor="hourly",unit="mm"} 0.0
+ecowitt_rain{sensor="daily",unit="mm"} 0.0
+ecowitt_rain{sensor="weekly",unit="mm"} 17.7
+ecowitt_rain{sensor="monthly",unit="mm"} 30.7
+ecowitt_rain{sensor="yearly",unit="mm"} 210.3
+ecowitt_rain{sensor="total",unit="mm"} 210.3
+# HELP ecowitt_lightning Lightning distance
+# TYPE ecowitt_lightning gauge
+ecowitt_lightning{unit="km"} 34.0
 # HELP ecowitt_lightning_num Lightning daily count
 # TYPE ecowitt_lightning_num gauge
 ecowitt_lightning_num 0.0
 # HELP ecowitt_lightning_time Lightning last strike
 # TYPE ecowitt_lightning_time gauge
 ecowitt_lightning_time 1.747849832e+09
-# HELP ecowitt_wh90_volt WS90 electrical energy stored
-# TYPE ecowitt_wh90_volt gauge
-# HELP ecowitt_soilmoisture_percent Soil moisture
-# TYPE ecowitt_soilmoisture_percent gauge
-ecowitt_soilmoisture_percent{sensor="soilmoisture1"} 0.0
+# HELP ecowitt_wh90 WS90 electrical energy stored
+# TYPE ecowitt_wh90 gauge
+# HELP ecowitt_soilmoisture Soil moisture
+# TYPE ecowitt_soilmoisture gauge
+ecowitt_soilmoisture{sensor="soilmoisture1",unit="percent"} 0.0
 ```
 
 ## Building and running locally

--- a/ecowitt_exporter.py
+++ b/ecowitt_exporter.py
@@ -112,7 +112,7 @@ def logecowitt():
         
         # Support for WS90 capacitor
         elif key in ['ws90cap_volt']:
-            addmetric(metric='ws90', label=[key], value=value)
+            addmetric(metric='ws90', label=[key, 'volt'], value=value)
 
         # Battery status & levels
         elif 'batt' in key:
@@ -128,7 +128,7 @@ def logecowitt():
 
         # Soil moisure
         elif key.startswith('soilmoisture'):
-            addmetric(metric='soilmoisture', label=[key], value=value)
+            addmetric(metric='soilmoisture', label=[key, 'percent'], value=value)
 
         # PM25
         # 'pm25_ch1', 'pm25_avg_24h_ch1'
@@ -172,7 +172,7 @@ def logecowitt():
                 case _:
                     label = f'ch{key[-1]}'
             # pylint: disable=used-before-assignment
-            addmetric(metric='humidity', label=[label], value=value)
+            addmetric(metric='humidity', label=[label, 'percent'], value=value)
 
         # Solar irradiance, default W/m^2
         elif key in ['solarradiation']:
@@ -180,7 +180,7 @@ def logecowitt():
                 value = wm22lux(value)
             elif irradiance_unit == 'fc':
                 value = wm22fc(value)
-            addmetric(metric='solarradiation', value=value)
+            addmetric(metric='solarradiation', label=[irradiance_unit], value=value)
 
         # Temperature, default Fahrenheit
         # 'tempinf', 'tempf', 'temp1f', 'temp2f', 'temp3f', 'temp4f', 'temp5f', 'temp6f', 'temp7f', 'temp8f'
@@ -200,7 +200,7 @@ def logecowitt():
             else:
                 label = f'ch{key[-1]}'
 
-            addmetric(metric='temp', label=[label], value=value)
+            addmetric(metric='temp', label=[label, temperature_unit], value=value)
 
         # Pressure, default inches Hg
         elif key.startswith('barom'):
@@ -215,7 +215,7 @@ def logecowitt():
                 label = 'relative'
             elif key == 'abs':
                 label = 'absolute'
-            addmetric(metric='barom', label=[label], value=value)
+            addmetric(metric='barom', label=[label, pressure_unit], value=value)
 
         # VPD, default inches Hg
         elif key in ['vpd']:
@@ -224,7 +224,7 @@ def logecowitt():
             elif pressure_unit == 'mmhg':
                 value = inhg2mmhg(value)
 
-            addmetric(metric='vpd', value=value)
+            addmetric(metric='vpd', label=[pressure_unit], value=value)
 
         # Wind speed, default mph
         elif key in ['windspeedmph', 'windgustmph', 'maxdailygust']:
@@ -238,7 +238,7 @@ def logecowitt():
                 value = mph2fps(value)
             if key != 'maxdailygust':
                 key = key[:-3]
-            addmetric(metric='wind', label=[key], value=value)
+            addmetric(metric='wind', label=[key, wind_unit], value=value)
 
             if key == 'windspeedmph':
                 beaufort = mph2beaufort(value)
@@ -258,15 +258,15 @@ def logecowitt():
                 value = in2mm(value)
             key = key[:-2]
             key = key.replace('rain', '')
-            addmetric(metric='rain', label=[key], value=value)
+            addmetric(metric='rain', label=[key, rain_unit], value=value)
 
         # Lightning distance, default kilometers
         elif key in ['lightning']:
             if distance_unit == 'km':
-                addmetric(metric='lightning', value=value)
+                addmetric(metric='lightning', label=[distance_unit], value=value)
             elif distance_unit == 'mi':
                 value = km2mi(value)
-                addmetric(metric='lightning', value=value)
+                addmetric(metric='lightning', label=[distance_unit], value=value)
 
 
     # Return a 200 to the weather station
@@ -283,26 +283,26 @@ if __name__ == "__main__":
     metrics['stationtype'] = Info(name='ecowitt_stationtype', documentation='Ecowitt station type')
     metrics['freq'] = Info(name='ecowitt_freq', documentation='Ecowitt radio frequency')
     metrics['model'] = Info(name='ecowitt_model', documentation='Ecowitt model')
-    metrics['temp'] = Gauge(name='ecowitt_temp', documentation='Temperature', unit=temperature_unit, labelnames=['sensor'])
-    metrics['humidity'] = Gauge(name='ecowitt_humidity', documentation='Relative humidity', unit='percent', labelnames=['sensor'])
-    metrics['winddir'] = Gauge(name='ecowitt_winddir', documentation='Wind direction', unit='degree')
+    metrics['temp'] = Gauge(name='ecowitt_temp', documentation='Temperature', labelnames=['sensor', 'unit'])
+    metrics['humidity'] = Gauge(name='ecowitt_humidity', documentation='Relative humidity', labelnames=['sensor', 'unit'])
+    metrics['winddir'] = Gauge(name='ecowitt_winddir', documentation='Wind direction')
     metrics['uv'] = Gauge(name='ecowitt_uv', documentation='UV index')
     metrics['pm25'] = Gauge(name='ecowitt_pm25', documentation='PM2.5 concentration', labelnames=['series', 'sensor'])
     metrics['aqi'] = Gauge(name='ecowitt_aqi', documentation='Air quality index', labelnames=['standard'])
     metrics['batterystatus'] = Gauge(name='ecowitt_batterystatus', documentation='Battery status', labelnames=['sensor'])
     metrics['batterylevel'] = Gauge(name='ecowitt_batterylevel', documentation='Battery level', labelnames=['sensor'])
     metrics['batteryvoltage'] = Gauge(name='ecowitt_batteryvoltage', documentation='Battery voltage', labelnames=['sensor'])
-    metrics['solarradiation'] = Gauge(name='ecowitt_solarradiation', documentation='Solar irradiance', unit='wm2')
-    metrics['barom'] = Gauge(name='ecowitt_barom', documentation='Barometer', unit=pressure_unit, labelnames=['sensor'])
-    metrics['vpd'] = Gauge(name='ecowitt_vpd', documentation='Vapour pressure deficit', unit=pressure_unit)
-    metrics['wind'] = Gauge(name='ecowitt_windspeed', documentation='Wind speed', unit=wind_unit, labelnames=['sensor'])
+    metrics['solarradiation'] = Gauge(name='ecowitt_solarradiation', documentation='Solar irradiance', labelnames=['unit'])
+    metrics['barom'] = Gauge(name='ecowitt_barom', documentation='Barometer', labelnames=['sensor', 'unit'])
+    metrics['vpd'] = Gauge(name='ecowitt_vpd', documentation='Vapour pressure deficit', labelnames=['unit'])
+    metrics['wind'] = Gauge(name='ecowitt_windspeed', documentation='Wind speed', labelnames=['sensor', 'unit'])
     metrics['wind_beaufort'] = Gauge(name='ecowitt_windspeed_beaufort', documentation='Wind Beaufort scale')
-    metrics['rain'] = Gauge(name='ecowitt_rain', documentation='Rainfall', unit=rain_unit, labelnames=['sensor'])
-    metrics['lightning'] = Gauge(name='ecowitt_lightning', documentation='Lightning distance', unit=distance_unit)
+    metrics['rain'] = Gauge(name='ecowitt_rain', documentation='Rainfall', labelnames=['sensor', 'unit'])
+    metrics['lightning'] = Gauge(name='ecowitt_lightning', documentation='Lightning distance', labelnames=['unit'])
     metrics['lightning_num'] = Gauge(name='ecowitt_lightning_num', documentation='Lightning daily count')
     metrics['lightning_time'] = Gauge(name='ecowitt_lightning_time', documentation='Lightning last strike')
-    metrics['ws90'] = Gauge(name='ecowitt_wh90', documentation='WS90 electrical energy stored', unit='volt', labelnames=['sensor'])
-    metrics['soilmoisture'] = Gauge(name='ecowitt_soilmoisture', documentation='Soil moisture', unit='percent', labelnames=['sensor'])
+    metrics['ws90'] = Gauge(name='ecowitt_wh90', documentation='WS90 electrical energy stored', labelnames=['sensor', 'unit'])
+    metrics['soilmoisture'] = Gauge(name='ecowitt_soilmoisture', documentation='Soil moisture', labelnames=['sensor', 'unit'])
 
     # Increase Flask logging if in debug mode
     if debug:


### PR DESCRIPTION
Don't set the unit of measurement in Prometheus config, as this appends the unit onto the metric name, which makes it harder to write Prometheus rules.

Instead we set the unit as a label on the metric so the information is not lost.

Fixes #44 