### PR TITLE
Use units as defined in Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,24 +54,25 @@ because NGINX magically fixes the headers on the fly.
 
 ## Environment variables
 
-Set the units for the export of each metric. Ecowitt weather stations always take measurements in Imperial.
-This exporter converts them on the fly if necessary, to present them to Prometheus in your desired format.
-Metric/SI is always the default. People in the USA will probably want to set everything to Imperial
-alternatives, while Brits will likely want a mixture of both!
+Set the units for the export of each metric. Ecowitt weather stations return readings in a mixture of Metric
+and Imperial units. This exporter converts them on the fly if necessary, to present them to Prometheus in
+your desired format. Metric/SI is always the default. People in the USA will probably want to set everything
+to Imperial alternatives, while Brits will likely want a mixture of both!
 
-All units are expressed in lower case and without slashes, for simplicity. Apologies to scientists,
-for whom this will be a difficult time.
+All units are expressed using their IDs in the
+[Grafana spec](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/valueFormats/categories.ts).
+Units not natively supported by Grafana are not supported here.
 
-| Variable           | Default | Choices                            | Meaning                                                                  |
-|--------------------|---------|------------------------------------|--------------------------------------------------------------------------|
-| `DEBUG`            | `no`    | `no`, `yes`                        | Enable extra output for debugging                                        |
-| `TEMPERATURE_UNIT` | `c`     | `c`, `f`, `k`                      | Temperature in Celsius, Fahrenheit or Kelvin                             |
-| `PRESSURE_UNIT`    | `hpa`   | `hpa`, `in`, `mmhg`                | Pressure in hectopascals (millibars), inches of mercury or mm of mercury |
-| `WIND_UNIT`        | `kmh`   | `kmh`, `mph`, `ms`, `knots`, `fps` | Speed in km/hour, miles/hour, metres/second, knots or feet/second        |
-| `RAIN_UNIT`        | `mm`    | `mm`, `in`                         | Rainfall in millimetres or inches                                        |
-| `IRRADIANCE_UNIT`  | `wm2`   | `wm2`, `lx`, `fc`                  | Solar irradiance in Watts/m^2                                            |
-| `DISTANCE_UNIT`    | `km`    | `km`, `mi`                         | Distance from the last lightning in kilometers                           |
-| `AQI_STANDARD`     | `uk`    | `uk`, `epa`, `mep`, `nepm`         | Air Quality Index standard in UK DAQI, US EPA, China MEP, Australia NEPM |
+| Variable           | Default       | Choices                                                    | Meaning                |
+|--------------------|---------------|------------------------------------------------------------|------------------------|
+| `DEBUG`            | `no`          | `no`, `yes`                                                | Enable extra output for debugging |
+| `TEMPERATURE_UNIT` | `celsius`     | `celsius`, `fahrenheit`, `kelvin`                          | Temperature in Celsius, Fahrenheit or Kelvin |
+| `PRESSURE_UNIT`    | `pressurehpa` | `pressurehpa`, `pressurehg`                                | Pressure in hectopascals (millibars) or inches of mercury |
+| `WIND_UNIT`        | `velocitykmh` | `velocitykmh`, `velocitymph`, `velocityms`, `velocityknot` | Speed in km/hour, miles/hour, metres/second, or knots |
+| `RAIN_UNIT`        | `lengthmm`    | `lengthmm`, `lengthin`                                     | Rainfall in millimetres or inches |
+| `IRRADIANCE_UNIT`  | `Wm2`         | `Wm2`, `lux`                                               | Solar irradiance in Watts/m^2 or Lux |
+| `DISTANCE_UNIT`    | `lengthkm`    | `lengthkm`, `lengthmi`                                     | Distance from the last lightning in kilometers or miles |
+| `AQI_STANDARD`     | `uk`          | `uk`, `epa`, `mep`, `nepm`                                 | Air Quality Index standard in UK DAQI, US EPA, China MEP, Australia NEPM |
 
 If you want to use one of the units that is not yet supported, please [open an issue](https://github.com/djjudas21/ecowitt-exporter/issues)
 and request it. I can add the code to convert and display other units if there is demand.

--- a/conversions.py
+++ b/conversions.py
@@ -15,11 +15,6 @@ def mph2kts(mph: str) -> str:
     knots = float(mph) / 1.151
     return "{:.2f}".format(knots)
 
-def mph2fps(mph: str) -> str:
-    '''Convert mph to fps'''
-    fps = float(mph) * 1.467
-    return "{:.2f}".format(fps)
-
 def in2mm(inches: str) -> str:
     '''Convert inches to mm'''
     mm = float(inches) * 25.4
@@ -35,19 +30,9 @@ def inhg2hpa(inhg: str) -> str:
     pressurehpa = float(inhg) * 33.8639
     return "{:.2f}".format(pressurehpa)
 
-def inhg2mmhg(inhg: str) -> str:
-    '''Convert inches Hg to mmHg'''
-    pressuremmhg = float(inhg) * 25.4
-    return "{:.2f}".format(pressuremmhg)
-
 def wm22lux(wm2: str) -> str:
     '''Convert degrees W/m2 to lux'''
     irradiance_lx = float(wm2) / 0.0079
-    return "{:.2f}".format(irradiance_lx)
-
-def wm22fc(wm2: str) -> str:
-    '''Convert degrees W/m2 to foot candle'''
-    irradiance_lx = float(wm2) * 6.345
     return "{:.2f}".format(irradiance_lx)
 
 def f2c(f: str) -> str:

--- a/ecowitt_exporter.py
+++ b/ecowitt_exporter.py
@@ -121,7 +121,7 @@ def logecowitt():
                 addmetric(metric='batterylevel', label=[key], value=value)
             # Battery voltage - returns a decimal voltage e.g. 1.7
             elif key.startswith('soil') or key.startswith('ws90'):
-                addmetric(metric='batteryvoltage', label=[key], value=value)
+                addmetric(metric='batteryvoltage', label=[key, 'volt'], value=value)
             # Battery status - returns 0 for OK and 1 for low
             else:
                 addmetric(metric='batterystatus', label=[key], value=value)
@@ -155,7 +155,7 @@ def logecowitt():
                 series = 'realtime'
 
             # Log the PM25 metric
-            addmetric(metric='pm25', label=[series, sensor], value=value)
+            addmetric(metric='pm25', label=[series, sensor, 'conμgm3'], value=value)
 
             # Calculate AQI from PM25
             if key.startswith('avg_24h'):
@@ -241,7 +241,7 @@ def logecowitt():
             if rain_unit == 'lengthmm':
                 value = in2mm(value)
             mkey = rainmaps[key]
-            addmetric(metric='rain', label=[key], value=value)
+            addmetric(metric='rain', label=[key, rain_unit], value=value)
 
         # Rainfall, default inches
         elif 'rain' in key:
@@ -277,11 +277,11 @@ if __name__ == "__main__":
     metrics['humidity'] = Gauge(name='ecowitt_humidity', documentation='Relative humidity', labelnames=['sensor', 'unit'])
     metrics['winddir'] = Gauge(name='ecowitt_winddir', documentation='Wind direction')
     metrics['uv'] = Gauge(name='ecowitt_uv', documentation='UV index')
-    metrics['pm25'] = Gauge(name='ecowitt_pm25', documentation='PM2.5 concentration', labelnames=['series', 'sensor'])
+    metrics['pm25'] = Gauge(name='ecowitt_pm25', documentation='PM2.5 concentration', labelnames=['series', 'sensor', 'unit'])
     metrics['aqi'] = Gauge(name='ecowitt_aqi', documentation='Air quality index', labelnames=['standard'])
     metrics['batterystatus'] = Gauge(name='ecowitt_batterystatus', documentation='Battery status', labelnames=['sensor'])
     metrics['batterylevel'] = Gauge(name='ecowitt_batterylevel', documentation='Battery level', labelnames=['sensor'])
-    metrics['batteryvoltage'] = Gauge(name='ecowitt_batteryvoltage', documentation='Battery voltage', labelnames=['sensor'])
+    metrics['batteryvoltage'] = Gauge(name='ecowitt_batteryvoltage', documentation='Battery voltage', labelnames=['sensor', 'unit'])
     metrics['solarradiation'] = Gauge(name='ecowitt_solarradiation', documentation='Solar irradiance', labelnames=['unit'])
     metrics['barom'] = Gauge(name='ecowitt_barom', documentation='Barometer', labelnames=['sensor', 'unit'])
     metrics['vpd'] = Gauge(name='ecowitt_vpd', documentation='Vapour pressure deficit', labelnames=['unit'])


### PR DESCRIPTION
* Switch to use unit names [as defined in Grafana](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/valueFormats/categories.ts)
* Drop units not supported by Grafana (feet per second, foot-candles and mmHg)
* Add more labels to metrics with units

Fixes #47 