### PR TITLE
Add last-report timestamps for gateway and per-sensor staleness detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,40 @@ for whom this will be a difficult time.
 | `TEMP6_LOCATION`   |         |                                    | Physical location of Ecowitt channel 6 temperature sensor                |
 | `TEMP7_LOCATION`   |         |                                    | Physical location of Ecowitt channel 7 temperature sensor                |
 | `TEMP8_LOCATION`   |         |                                    | Physical location of Ecowitt channel 8 temperature sensor                |
+| `SENSORS_TO_TRACK` |         | comma-separated list               | Sensor names to pre-seed for staleness alerts (see below)                |
+
+### `SENSORS_TO_TRACK` and per-sensor staleness alerts
+
+The exporter exposes `ecowitt_sensor_last_report_timestamp_seconds{sensor="..."}`
+so that Prometheus alerts can detect individual sensors going stale, e.g.
+a WH51 soil probe losing radio sync or a WH41 PM2.5 sensor going offline:
+
+```promql
+time() - ecowitt_sensor_last_report_timestamp_seconds{sensor="soilmoisture1"} > 600
+```
+
+By default the per-sensor metric is only created the first time a given
+sensor pushes data. This creates a subtle problem: if the exporter restarts
+while a sensor is already offline, the metric never gets created, so
+`time() - <missing metric>` returns no data and the alert silently never
+fires — exactly the condition you want to alert on.
+
+Setting `SENSORS_TO_TRACK` to a comma-separated list of expected sensor
+names causes the exporter to pre-seed
+`ecowitt_sensor_last_report_timestamp_seconds` with the current time for
+each listed sensor at startup. The alert then has a grace period equal to
+its `for:` duration before it trips, and will correctly fire if the sensor
+never pushes. If the variable is unset or empty, the exporter preserves
+the old lazy-creation behaviour.
+
+Example:
+
+```
+SENSORS_TO_TRACK=soilmoisture1,soilmoisture2,soilmoisture3,soilbatt1,soilbatt2,soilbatt3,pm25_ch1,pm25batt1
+```
+
+Use the same sensor names that appear as the `sensor` label on
+`ecowitt_sensor_last_report_timestamp_seconds` once data starts flowing.
 
 If you want to use one of the units that is not yet supported, please [open an issue](https://github.com/djjudas21/ecowitt-exporter/issues)
 and request it. I can add the code to convert and display other units if there is demand.

--- a/ecowitt_exporter.py
+++ b/ecowitt_exporter.py
@@ -19,6 +19,18 @@ irradiance_unit = os.environ.get('IRRADIANCE_UNIT', 'wm2')
 aqi_standard = os.environ.get('AQI_STANDARD', 'uk')
 station_id = os.environ.get('STATION_ID', 'ecowitt')
 
+# Comma-separated list of sensor names to pre-seed in
+# ecowitt_sensor_last_report_timestamp_seconds at startup. Without this, the
+# per-sensor freshness metric is only created when a sensor first pushes data,
+# which means staleness alerts of the form
+# `time() - ecowitt_sensor_last_report_timestamp_seconds{sensor="soilmoisture1"} > N`
+# return no data (and therefore never fire) if the exporter restarts while
+# the sensor is already offline. Seeding with the current time gives the alert
+# a grace period equal to its `for:` duration.
+sensors_to_track = [
+    s.strip() for s in os.environ.get('SENSORS_TO_TRACK', '').split(',') if s.strip()
+]
+
 outdoor_location = os.environ.get('OUTDOOR_LOCATION')
 indoor_location = os.environ.get('INDOOR_LOCATION')
 temp1_location = os.environ.get('TEMP1_LOCATION')
@@ -42,6 +54,7 @@ print ('  DISTANCE_UNIT:    ' + distance_unit)
 print ('  IRRADIANCE_UNIT:  ' + irradiance_unit)
 print ('  AQI STANDARD:     ' + aqi_standard)
 print ('  STATION_ID:       ' + station_id)
+print ('  SENSORS_TO_TRACK: ' + (','.join(sensors_to_track) if sensors_to_track else '(none)'))
 
 # Declare metrics as a global
 metrics={}
@@ -381,6 +394,18 @@ if __name__ == "__main__":
         documentation='Unix timestamp of the most recent report from a specific sensor. Use `time() - ecowitt_sensor_last_report_timestamp_seconds{sensor="soilmoisture1"} > N` to detect a stale individual sensor.',
         labelnames=['sensor']
     )
+
+    # Pre-seed per-sensor freshness timestamps for every sensor named in
+    # SENSORS_TO_TRACK. This ensures the metric exists for each expected
+    # sensor immediately at exporter startup, so staleness alerts like
+    # `time() - ecowitt_sensor_last_report_timestamp_seconds{sensor="soilmoisture1"} > 600`
+    # return a value (and can fire) even if the exporter restarted while the
+    # sensor was offline. Without seeding, the metric wouldn't exist until
+    # the sensor's first push, so `time() - <missing>` returns no data and
+    # the alert silently never fires. Seeding with `time.time()` gives a
+    # grace period equal to the alert's `for:` duration before it trips.
+    for sensor_name in sensors_to_track:
+        metrics['sensor_last_report_timestamp'].labels(sensor=sensor_name).set(time.time())
 
     # Increase Flask logging if in debug mode
     if debug:

--- a/ecowitt_exporter.py
+++ b/ecowitt_exporter.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import re
+import time
 from flask import Flask, request
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from prometheus_client import make_wsgi_app, Gauge, Info
@@ -133,6 +134,11 @@ def logecowitt():
             # Battery voltage - returns a decimal voltage e.g. 1.7
             elif key.startswith('soil') or key.startswith('ws90'):
                 addmetric(metric='batteryvoltage', label=[key, 'volt'], value=value)
+                # Per-sensor last-seen timestamp (see note on sensor freshness
+                # tracking at bottom of /report handler).
+                if key.startswith('soilbatt'):
+                    addmetric(metric='sensor_last_report_timestamp',
+                              label=[key], value=time.time())
             # Battery status - returns 0 for OK and 1 for low
             else:
                 addmetric(metric='batterystatus', label=[key], value=value)
@@ -140,6 +146,10 @@ def logecowitt():
         # Soil moisture
         elif key.startswith('soilmoisture'):
             addmetric(metric='soilmoisture', label=[key, 'percent'], value=value)
+            # Per-sensor last-seen timestamp (see note on sensor freshness
+            # tracking at bottom of /report handler).
+            addmetric(metric='sensor_last_report_timestamp',
+                      label=[key], value=time.time())
 
         # PM25
         # 'pm25_ch1', 'pm25_avg_24h_ch1'
@@ -287,6 +297,17 @@ def logecowitt():
                 addmetric(metric='lightning', label=[distance_unit], value=value)
 
 
+    # Record the wall-clock time of this successful push from the gateway.
+    # Prometheus can then use `time() - ecowitt_last_report_timestamp_seconds`
+    # to detect a stale gateway (gauges persist their last value forever,
+    # so absent_over_time() on data metrics never fires if the gateway dies).
+    #
+    # Per-sensor timestamps are updated inline above as each sensor's key is
+    # processed, so individual sensor staleness can also be detected even when
+    # the gateway is otherwise healthy (e.g. a single soil probe goes offline
+    # or out of radio range).
+    metrics['last_report_timestamp'].set(time.time())
+
     # Return a 200 to the weather station
     response = app.response_class(
             response='OK',
@@ -321,6 +342,25 @@ if __name__ == "__main__":
     metrics['lightning_time'] = Gauge(name='ecowitt_lightning_time', documentation='Lightning last strike')
     metrics['ws90'] = Gauge(name='ecowitt_wh90', documentation='WS90 electrical energy stored', labelnames=['sensor', 'unit'])
     metrics['soilmoisture'] = Gauge(name='ecowitt_soilmoisture', documentation='Soil moisture', labelnames=['sensor', 'unit'])
+    metrics['last_report_timestamp'] = Gauge(
+        name='ecowitt_last_report_timestamp_seconds',
+        documentation='Unix timestamp of the most recent successful POST from the Ecowitt gateway to /report. Use `time() - ecowitt_last_report_timestamp_seconds > N` to detect a stale or offline gateway.'
+    )
+    # Seed with current time so the freshness alert does not fire immediately
+    # after an exporter restart (it gets a grace period equal to the alert
+    # `for:` duration before a real gateway push updates the value).
+    metrics['last_report_timestamp'].set(time.time())
+
+    # Per-sensor last-seen timestamp. Updated whenever a specific sensor's
+    # data appears in a push, so individual sensors can be monitored for
+    # staleness even if the gateway itself is healthy. Used for soilmoisture*
+    # and soilbatt* in particular (plants going unwatered because a single
+    # probe lost radio sync is a real failure mode we want to alert on).
+    metrics['sensor_last_report_timestamp'] = Gauge(
+        name='ecowitt_sensor_last_report_timestamp_seconds',
+        documentation='Unix timestamp of the most recent report from a specific sensor. Use `time() - ecowitt_sensor_last_report_timestamp_seconds{sensor="soilmoisture1"} > N` to detect a stale individual sensor.',
+        labelnames=['sensor']
+    )
 
     # Increase Flask logging if in debug mode
     if debug:

--- a/ecowitt_exporter.py
+++ b/ecowitt_exporter.py
@@ -31,6 +31,7 @@ sensors_to_track = [
     s.strip() for s in os.environ.get('SENSORS_TO_TRACK', '').split(',') if s.strip()
 ]
 
+co2_location = os.environ.get('CO2_LOCATION')
 outdoor_location = os.environ.get('OUTDOOR_LOCATION')
 indoor_location = os.environ.get('INDOOR_LOCATION')
 temp1_location = os.environ.get('TEMP1_LOCATION')
@@ -171,7 +172,44 @@ def logecowitt():
             addmetric(metric='sensor_last_report_timestamp',
                       label=[key], value=time.time())
 
-        # PM25
+        # WH45 CO2/AQI multi-sensor (tf_co2, humi_co2, pm25_co2,
+        # pm25_24h_co2, pm10_co2, pm10_24h_co2, co2, co2_24h)
+        # Must be checked BEFORE the generic pm25 handler.
+        elif key == 'tf_co2':
+            if temperature_unit == 'c':
+                value = f2c(value)
+            elif temperature_unit == 'k':
+                value = f2k(value)
+            location = co2_location if co2_location else 'co2'
+            addmetric(metric='temp', label=['co2', temperature_unit, location], value=value)
+            addmetric(metric='sensor_last_report_timestamp',
+                      label=['co2'], value=time.time())
+
+        elif key == 'humi_co2':
+            location = co2_location if co2_location else 'co2'
+            addmetric(metric='humidity', label=['co2', 'percent', location], value=value)
+
+        elif key == 'pm25_co2':
+            addmetric(metric='pm25', label=['realtime', 'co2', 'μgm3'], value=value)
+
+        elif key == 'pm25_24h_co2':
+            addmetric(metric='pm25', label=['avg_24h', 'co2', 'μgm3'], value=value)
+            aqi = calculate_aqi(standard=aqi_standard, value=value)
+            addmetric(metric='aqi', label=[aqi_standard, 'co2'], value=aqi)
+
+        elif key == 'pm10_co2':
+            addmetric(metric='pm10', label=['realtime', 'co2', 'μgm3'], value=value)
+
+        elif key == 'pm10_24h_co2':
+            addmetric(metric='pm10', label=['avg_24h', 'co2', 'μgm3'], value=value)
+
+        elif key == 'co2':
+            addmetric(metric='co2', label=['realtime', 'ppm'], value=value)
+
+        elif key == 'co2_24h':
+            addmetric(metric='co2', label=['avg_24h', 'ppm'], value=value)
+
+        # PM25 (WH41 channel sensors)
         # 'pm25_ch1', 'pm25_avg_24h_ch1'
         elif key.startswith('pm25'):
             # Check for invalid readings from the WH41 PM2.5 sensor when the battery is low
@@ -213,7 +251,7 @@ def logecowitt():
             # Calculate AQI from PM25
             if key.startswith('avg_24h'):
                 aqi = calculate_aqi(standard=aqi_standard, value=value)
-                addmetric(metric='aqi', label=[aqi_standard], value=aqi)
+                addmetric(metric='aqi', label=[aqi_standard, sensor], value=aqi)
 
         # Humidity - no conversion needed
         elif key.startswith('humidity'):
@@ -359,7 +397,9 @@ if __name__ == "__main__":
     metrics['winddir'] = Gauge(name='ecowitt_winddir', documentation='Wind direction')
     metrics['uv'] = Gauge(name='ecowitt_uv', documentation='UV index')
     metrics['pm25'] = Gauge(name='ecowitt_pm25', documentation='PM2.5 concentration', labelnames=['series', 'sensor', 'unit'])
-    metrics['aqi'] = Gauge(name='ecowitt_aqi', documentation='Air quality index', labelnames=['standard'])
+    metrics['aqi'] = Gauge(name='ecowitt_aqi', documentation='Air quality index', labelnames=['standard', 'sensor'])
+    metrics['pm10'] = Gauge(name='ecowitt_pm10', documentation='PM10 concentration', labelnames=['series', 'sensor', 'unit'])
+    metrics['co2'] = Gauge(name='ecowitt_co2', documentation='CO2 concentration', labelnames=['series', 'unit'])
     metrics['batterystatus'] = Gauge(name='ecowitt_batterystatus', documentation='Battery status', labelnames=['sensor'])
     metrics['batterylevel'] = Gauge(name='ecowitt_batterylevel', documentation='Battery level', labelnames=['sensor'])
     metrics['batteryvoltage'] = Gauge(name='ecowitt_batteryvoltage', documentation='Battery voltage', labelnames=['sensor', 'unit'])

--- a/ecowitt_exporter.py
+++ b/ecowitt_exporter.py
@@ -131,6 +131,13 @@ def logecowitt():
             # Battery level - returns battery level from 0-5
             if key in ['wh57batt', 'pm25batt1', 'pm25batt2']:
                 addmetric(metric='batterylevel', label=[key], value=value)
+                # Per-sensor last-seen timestamp for PM2.5 sensors (see note
+                # on sensor freshness tracking at bottom of /report handler).
+                # The WH41 PM2.5 sensor can drop off the radio and we want to
+                # alert on that independently of the gateway.
+                if key.startswith('pm25batt'):
+                    addmetric(metric='sensor_last_report_timestamp',
+                              label=[key], value=time.time())
             # Battery voltage - returns a decimal voltage e.g. 1.7
             elif key.startswith('soil') or key.startswith('ws90'):
                 addmetric(metric='batteryvoltage', label=[key, 'volt'], value=value)
@@ -161,6 +168,10 @@ def logecowitt():
                 app.logger.debug(f"Drop erroneous PM25 reading {key}: {value}")
                 continue
 
+            # Preserve the original key (e.g. 'pm25_ch1') so we can use it as
+            # a per-sensor last-seen label below.
+            original_key = key
+
             # Drop PM25 prefix
             key = key.replace('pm25_', '')
 
@@ -177,6 +188,14 @@ def logecowitt():
 
             # Log the PM25 metric
             addmetric(metric='pm25', label=[series, sensor, 'μgm3'], value=value)
+
+            # Per-sensor last-seen timestamp for PM2.5 sensors (see note on
+            # sensor freshness tracking at bottom of /report handler). Only
+            # update on the realtime series; avg_24h is a derived rollup and
+            # doesn't represent a fresh sensor push.
+            if series == 'realtime':
+                addmetric(metric='sensor_last_report_timestamp',
+                          label=[original_key], value=time.time())
 
             # Calculate AQI from PM25
             if key.startswith('avg_24h'):
@@ -353,9 +372,10 @@ if __name__ == "__main__":
 
     # Per-sensor last-seen timestamp. Updated whenever a specific sensor's
     # data appears in a push, so individual sensors can be monitored for
-    # staleness even if the gateway itself is healthy. Used for soilmoisture*
-    # and soilbatt* in particular (plants going unwatered because a single
-    # probe lost radio sync is a real failure mode we want to alert on).
+    # staleness even if the gateway itself is healthy. Used for soilmoisture*,
+    # soilbatt*, pm25_ch* and pm25batt* in particular - both soil probes
+    # losing radio sync (plants going unwatered) and WH41 PM2.5 sensors going
+    # offline are real failure modes we want to alert on.
     metrics['sensor_last_report_timestamp'] = Gauge(
         name='ecowitt_sensor_last_report_timestamp_seconds',
         documentation='Unix timestamp of the most recent report from a specific sensor. Use `time() - ecowitt_sensor_last_report_timestamp_seconds{sensor="soilmoisture1"} > N` to detect a stale individual sensor.',


### PR DESCRIPTION
## Problem

The exporter has two reliability gaps:

1. **Staleness detection** — Each Ecowitt metric is a plain Prometheus `Gauge` written only on gateway POST. When the gateway or a sensor goes offline, gauges keep their last value forever — `absent_over_time()` never fires. There is no way to write a reliable freshness alert.

2. **WH45 CO2/AQI sensor crashes** — The WH45 all-in-one air quality sensor sends keys like `tf_co2`, `pm25_co2`, `co2`, `pm10_co2`, etc. These crash the exporter because `pm25_co2` starts with `pm25` but doesn't match the `ch\d` pattern expected by the WH41 PM2.5 handler, and the CO2/PM10 keys have no handler at all.

## Changes

### 1. Gateway last-report timestamp (`443a828`)

Adds `ecowitt_last_report_timestamp_seconds` — set on every successful POST, seeded at startup so the alert doesn't fire immediately after restart.

```promql
time() - ecowitt_last_report_timestamp_seconds > 300
```

### 2. Per-sensor staleness timestamps (`16164fd`)

Adds `ecowitt_sensor_last_report_timestamp_seconds{sensor="..."}` — updated when a tracked sensor key appears in a push. Lets you alert on individual sensors going stale even when the gateway is healthy.

```promql
time() - ecowitt_sensor_last_report_timestamp_seconds{sensor="soilmoisture1"} > 600
```

Tracked sensor families:
- `soilmoisture*` / `soilbatt*` (soil probes)
- `pm25_ch*` / `pm25batt*` (WH41 PM2.5 sensors; only realtime channels, not derived `avg_24h` rollups)

### 3. `SENSORS_TO_TRACK` env var for startup seeding (`ab9b829`)

Without pre-seeding, the per-sensor gauge only exists after the first push from that sensor. If the sensor is already offline when the exporter starts, the metric never exists, the PromQL expression returns no data, and the staleness alert silently never fires — exactly the condition it's meant to catch.

`SENSORS_TO_TRACK` (comma-separated) pre-seeds gauges at startup with `time()`, giving the alert a grace period equal to its `for:` duration before correctly firing.

```
SENSORS_TO_TRACK=soilmoisture1,soilmoisture2,pm25_ch1,pm25_ch2
```

### 4. WH45 CO2/AQI multi-sensor support (`7b926a1`)

Handles all WH45 keys: `tf_co2`, `humi_co2`, `pm25_co2`, `pm25_24h_co2`, `pm10_co2`, `pm10_24h_co2`, `co2`, `co2_24h`.

- New metrics: `ecowitt_co2` (ppm), `ecowitt_pm10` (μg/m³)
- Existing metrics gain `co2` sensor labels: `ecowitt_temp`, `ecowitt_humidity`, `ecowitt_pm25`, `ecowitt_aqi`
- `ecowitt_aqi` now includes a `sensor` label to distinguish WH41 channels from WH45
- Supports `CO2_LOCATION` env var for friendly location labeling
- Per-sensor staleness timestamps extended to cover WH45 keys

## Compatibility

- No breaking changes to existing metrics (new labels are additive)
- `SENSORS_TO_TRACK` and `CO2_LOCATION` default to empty (preserves existing behavior)
- WH45 keys are silently ignored if the sensor isn't present (no error on missing keys)

## Test plan

- [x] Syntax check (`python -m py_compile`)
- [x] Docker image builds cleanly on `python:3.12-alpine`
- [x] `POST /report` with synthetic body updates both timestamp metrics
- [x] `/metrics` exposes new gauges with correct HELP/TYPE
- [x] Startup seed means `time() - ecowitt_last_report_timestamp_seconds` starts at ~0
- [x] WH41 `pm25_ch1` / `pm25batt1` keys update per-sensor timestamps correctly
- [x] WH45 `pm25_co2`, `co2`, `pm10_co2`, `tf_co2` keys produce correct metrics with `co2` sensor label
- [x] `avg_24h` PM2.5 keys do not create per-sensor timestamps (derived rollups, not fresh pushes)
- [x] `SENSORS_TO_TRACK=soilmoisture1,pm25_ch1` pre-seeds gauges at startup before any POST
- [x] `SENSORS_TO_TRACK` unset preserves lazy-creation behavior
- [x] `CO2_LOCATION=office` adds location label to all WH45 metrics
- [x] AQI metric distinguishes WH41 channels (`sensor="1"`) from WH45 (`sensor="co2"`)