### PR TITLE
Add last24hrain_piezo and srain_piezo support for WS2000 gateway

### DIFF
--- a/ecowitt_exporter.py
+++ b/ecowitt_exporter.py
@@ -79,7 +79,8 @@ rainmaps = {
         "drain_piezo": "dailyrain",
         "wrain_piezo": "weeklyrain",
         "mrain_piezo": "monthlyrain",
-        "yrain_piezo": "yearlyrain"
+        "yrain_piezo": "yearlyrain",
+        "last24hrain_piezo": "last24hrain"
 }
 
 # pylint: disable=dangerous-default-value
@@ -342,7 +343,12 @@ def logecowitt():
                 key = key[:-3]
             addmetric(metric='wind', label=[key, wind_unit], value=value)
         
-        # Support for WS90 with a haptic rain sensor
+        # Support for WS90 with a haptic rain sensor (rain state)
+        elif key == 'srain_piezo':
+            # Rain state: 0 = no rain, 1 = rain
+            addmetric(metric='rain_state', label=[key], value=value)
+
+        # Support for WS90 with a haptic rain sensor (cumulative rain amounts)
         elif key.endswith('piezo'):
             if rain_unit == 'mm':
                 value = in2mm(value)
@@ -409,6 +415,7 @@ if __name__ == "__main__":
     metrics['wind'] = Gauge(name='ecowitt_windspeed', documentation='Wind speed', labelnames=['sensor', 'unit'])
     metrics['wind_beaufort'] = Gauge(name='ecowitt_windspeed_beaufort', documentation='Wind Beaufort scale')
     metrics['rain'] = Gauge(name='ecowitt_rain', documentation='Rainfall', labelnames=['sensor', 'unit'])
+    metrics['rain_state'] = Gauge(name='ecowitt_rain_state', documentation='Rain state (0=no rain, 1=rain)', labelnames=['sensor'])
     metrics['lightning'] = Gauge(name='ecowitt_lightning', documentation='Lightning distance', labelnames=['unit'])
     metrics['lightning_num'] = Gauge(name='ecowitt_lightning_num', documentation='Lightning daily count')
     metrics['lightning_time'] = Gauge(name='ecowitt_lightning_time', documentation='Lightning last strike')


### PR DESCRIPTION
Fixes missing keys sent by: 
GW2000 gateway + WS90 Sensor
Firmware version v3.3.1

- Add last24hrain_piezo to rainmaps for cumulative 24-hour rain tracking
- Add new rain_state metric for srain_piezo (rain/no-rain state) - addresses #58 

Prometheus metrics added:
```
ecowitt_rain_state
```

Payload captured:

```
PASSKEY=A6DAEBF74134D04C655F5CECREDACTED&stationtype=GW2000A_V3.3.1&runtime=65881&heap=70388&dateutc=2026-05-01+14:58:04&tempinf=71.42&humidityin=58&baromrelin=30.301&baromabsin=29.684&tempf=69.80&humidity=60&vpd=0.294&winddir=206&winddir_avg10m=201&windspeedmph=6.71&windgustmph=10.29&maxdailygust=10.74&solarradiation=425.85&uv=2&rrain_piezo=0.000&erain_piezo=0.000&hrain_piezo=0.000&last24hrain_piezo=0.004&drain_piezo=0.004&wrain_piezo=1.130&mrain_piezo=0.004&yrain_piezo=19.669&srain_piezo=0&ws90cap_volt=5.2&ws90_ver=156&wh90batt=2.94&freq=868M&model=GW2000A&interval=30
```